### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/abdessfadil/3d4df268-104d-460e-8035-d804c2bf665c/abf2b492-cea0-44ae-85e2-73ac7a405feb/_apis/work/boardbadge/0b008d0b-9661-482c-8251-ff67cb67c0bc)](https://dev.azure.com/abdessfadil/3d4df268-104d-460e-8035-d804c2bf665c/_boards/board/t/abf2b492-cea0-44ae-85e2-73ac7a405feb/Microsoft.RequirementCategory)
 [![Build Status](https://dev.azure.com/abdessfadil/first%20project/_apis/build/status/abdessamadfadil.pipelines-java?branchName=master)](https://dev.azure.com/abdessfadil/first%20project/_build/latest?definitionId=1&branchName=master)
 # Contributing
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/abdessfadil/3d4df268-104d-460e-8035-d804c2bf665c/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.